### PR TITLE
Version 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog (Sorted by Date in Descending Order)
 
+## 1.3.0.0
+
+* Added overloads of `Upsert` that accept a `string` key, while the `ReadOnlySpan<char>` overloads are amazing in specific cases where its use can prevent a string allocation for the lookup, in other places where the input was originally a `string` that was implicitly converted to a `ReadOnlySpan<char>` for the parameter, this would've caused a copy to be allocated for the key when the key did not exist. The same scenario will now use the `string` overload and use it for the key directly, avoiding the intermediate copy.
+* Added a `ValueTask` based `GetOrAddAsync` method, commonly used in caching scenarios.
+
 ## 1.2.0.0
 
 * An overload to `Upsert` without `updateCondition` was added and would now act as default path in case `updateCondition` wasn't specified, this should further optimize such cases by removing condition checks and another reference from the stack during runtime.

--- a/src/ArrowDbCore/ArrowDb.GetOrAdd.cs
+++ b/src/ArrowDbCore/ArrowDb.GetOrAdd.cs
@@ -10,15 +10,15 @@ public partial class ArrowDb {
 	/// <typeparam name="TValue">The type of the value to get or add</typeparam>
 	/// <param name="key">The key at which to find or add the value</param>
 	/// <param name="jsonTypeInfo">The json type info for the value type</param>
-	/// <param name="factory">The function used to generate a value for the key</param>
+	/// <param name="valueFactory">The function used to generate a value for the key</param>
 	/// <returns>The value after finding or adding it</returns>
 	/// <remarks>
 	/// </remarks>
-	public async ValueTask<TValue> GetOrAddAsync<TValue>(string key, JsonTypeInfo<TValue> jsonTypeInfo, Func<string, ValueTask<TValue>> factory) {
+	public async ValueTask<TValue> GetOrAddAsync<TValue>(string key, JsonTypeInfo<TValue> jsonTypeInfo, Func<string, ValueTask<TValue>> valueFactory) {
 		if (Lookup.TryGetValue(key, out var source)) {
 			return JsonSerializer.Deserialize(new ReadOnlySpan<byte>(source), jsonTypeInfo)!;
 		}
-		var val = await factory(key);
+		var val = await valueFactory(key);
 		Upsert(key, val, jsonTypeInfo);
 		return val;
 	}

--- a/src/ArrowDbCore/ArrowDb.GetOrAdd.cs
+++ b/src/ArrowDbCore/ArrowDb.GetOrAdd.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ArrowDbCore;
+
+public partial class ArrowDb {
+	/// <summary>
+	/// Tries to retrieve a value stored in the database under <paramref name="key"/>, if doesn't exist, it uses the factory to create and add it, then returns it.
+	/// </summary>
+	/// <typeparam name="TValue">The type of the value to get or add</typeparam>
+	/// <param name="key">The key at which to find or add the value</param>
+	/// <param name="jsonTypeInfo">The json type info for the value type</param>
+	/// <param name="factory">The function used to generate a value for the key</param>
+	/// <returns>The value after finding or adding it</returns>
+	/// <remarks>
+	/// </remarks>
+	public async ValueTask<TValue> GetOrAddAsync<TValue>(string key, JsonTypeInfo<TValue> jsonTypeInfo, Func<string, ValueTask<TValue>> factory) {
+		if (Lookup.TryGetValue(key, out var source)) {
+			return JsonSerializer.Deserialize(new ReadOnlySpan<byte>(source), jsonTypeInfo)!;
+		}
+		var val = await factory(key);
+		Upsert(key, val, jsonTypeInfo);
+		return val;
+	}
+}

--- a/src/ArrowDbCore/ArrowDb.IDictionaryAccessor.cs
+++ b/src/ArrowDbCore/ArrowDb.IDictionaryAccessor.cs
@@ -1,0 +1,37 @@
+﻿namespace ArrowDbCore;
+
+public partial class ArrowDb {
+	/// <summary>
+	/// Provides an interface that unifies methods of upserting values to ArrowDb
+	/// </summary>
+	/// <typeparam name="TKey"></typeparam>
+	private interface IDictionaryAccessor<TKey> where TKey : allows ref struct {
+		/// <summary>
+		/// Assigns the <paramref name="value"/> to the <paramref name="key"/> in <paramref name="instance"/>
+		/// </summary>
+		/// <param name="instance">The ArrowDb instance</param>
+		/// <param name="key">The key to use</param>
+		/// <param name="value">The value to add/update</param>
+		void Upsert(ArrowDb instance, TKey key, byte[] value);
+	}
+
+	/// <summary>
+	/// Implements <see cref="IDictionaryAccessor{TKey}"/> by using the source dictionary directly
+	/// </summary>
+	private readonly ref struct StringAccessor : IDictionaryAccessor<string> {
+		/// <inheritdoc />
+		public void Upsert(ArrowDb instance, string key, byte[] value) {
+			instance.Source[key] = value;
+		}
+	}
+
+	/// <summary>
+	/// Implements <see cref="IDictionaryAccessor{TKey}"/> by using the lookup
+	/// </summary>
+    private readonly ref struct ReadOnlySpanAccessor : IDictionaryAccessor<ReadOnlySpan<char>> {
+		/// <inheritdoc />
+        public void Upsert(ArrowDb instance, ReadOnlySpan<char> key, byte[] value) {
+			instance.Lookup[key] = value;
+		}
+    }
+}

--- a/src/ArrowDbCore/ArrowDb.Upsert.cs
+++ b/src/ArrowDbCore/ArrowDb.Upsert.cs
@@ -12,6 +12,25 @@ public partial class ArrowDb {
 	/// <param name="value">The value to upsert</param>
 	/// <param name="jsonTypeInfo">The json type info for the value type</param>
 	/// <returns>True</returns>
+	public bool Upsert<TValue>(string key, TValue value, JsonTypeInfo<TValue> jsonTypeInfo) {
+		WaitIfSerializing(); // block if the database is currently serializing
+		byte[] utf8value = JsonSerializer.SerializeToUtf8Bytes(value, jsonTypeInfo);
+		Source[key] = utf8value;
+		OnChangeInternal(ArrowDbChangeEventArgs.Upsert); // trigger change event
+		return true;
+	}
+
+	/// <summary>
+	/// Upsert the specified key with the specified value into the database
+	/// </summary>
+	/// <typeparam name="TValue">The type of the value to upsert</typeparam>
+	/// <param name="key">The key at which to upsert the value</param>
+	/// <param name="value">The value to upsert</param>
+	/// <param name="jsonTypeInfo">The json type info for the value type</param>
+	/// <returns>True</returns>
+	/// <remarks>
+	/// This method overload which uses ReadOnlySpan{char} will not allocate a new string for the key if it already exists, instead it will directly replace the value
+	/// </remarks>
 	public bool Upsert<TValue>(ReadOnlySpan<char> key, TValue value, JsonTypeInfo<TValue> jsonTypeInfo) {
 		WaitIfSerializing(); // block if the database is currently serializing
 		byte[] utf8value = JsonSerializer.SerializeToUtf8Bytes(value, jsonTypeInfo);
@@ -36,6 +55,34 @@ public partial class ArrowDb {
 	/// <para>1. <paramref name="updateCondition"/> is not null</para>
 	/// <para>2. A value for the specified key exists and successfully deserialized to <typeparamref name="TValue"/></para>
 	/// <para>3. <paramref name="updateCondition"/> on the reference value returns false</para>
+	/// </remarks>
+	public bool Upsert<TValue>(string key, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, Func<TValue, bool> updateCondition) {
+		if (TryGetValue(key, jsonTypeInfo, out TValue existingReference) &&
+			 !updateCondition(existingReference)) {
+			return false;
+		}
+		return Upsert(key, value, jsonTypeInfo);
+	}
+
+	/// <summary>
+	/// Tries to upsert the specified key with the specified value into the database
+	/// </summary>
+	/// <typeparam name="TValue">The type of the value to upsert</typeparam>
+	/// <param name="key">The key at which to upsert the value</param>
+	/// <param name="value">The value to upsert</param>
+	/// <param name="jsonTypeInfo">The json type info for the value type</param>
+	/// <param name="updateCondition">A conditional check that determines whether this update should be performed</param>
+	/// <returns>True if the value was upserted, false otherwise</returns>
+	/// <remarks>
+	/// <para>
+	/// <paramref name="updateCondition"/> can be used to resolve write conflicts, the update will be rejected only if all of the following conditions are met:
+	/// </para>
+	/// <para>1. <paramref name="updateCondition"/> is not null</para>
+	/// <para>2. A value for the specified key exists and successfully deserialized to <typeparamref name="TValue"/></para>
+	/// <para>3. <paramref name="updateCondition"/> on the reference value returns false</para>
+	/// <para>
+	/// This method overload which uses ReadOnlySpan{char} will not allocate a new string for the key if it already exists, instead it will directly replace the value
+	/// </para>
 	/// </remarks>
 	public bool Upsert<TValue>(ReadOnlySpan<char> key, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, Func<TValue, bool> updateCondition) {
 		if (TryGetValue(key, jsonTypeInfo, out TValue existingReference) &&

--- a/src/ArrowDbCore/ArrowDbCore.csproj
+++ b/src/ArrowDbCore/ArrowDbCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.2.0.0</Version>
+    <Version>1.3.0.0</Version>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/tests/ArrowDbCore.Tests.Unit/GetOrAddAsync.cs
+++ b/tests/ArrowDbCore.Tests.Unit/GetOrAddAsync.cs
@@ -1,0 +1,34 @@
+﻿namespace ArrowDbCore.Tests.Unit;
+
+public class GetOrAddAsync {
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+// this is required here for testing purposes
+    [Fact]
+    public async Task GetOrAddAsync_ReturnsSynchronously_WhenExists() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        db.Upsert("1", 1, JContext.Default.Int32); // add before
+        var task = db.GetOrAddAsync("1", JContext.Default.Int32, async _ => {
+            await Task.Delay(1000);
+            return 1;
+        });
+        Assert.True(task.IsCompletedSuccessfully);
+
+        Assert.Equal(1, task.GetAwaiter().GetResult());
+
+    }
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
+    [Fact]
+    public async Task GetOrAddAsync_ReturnsAsynchronously_WhenNotExists() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        // doesn't exist
+        var task = db.GetOrAddAsync("1", JContext.Default.Int32, async _ => {
+            await Task.Delay(1000);
+            return 1;
+        });
+        Assert.False(task.IsCompletedSuccessfully);
+        Assert.Equal(1, await task);
+    }
+}

--- a/tests/ArrowDbCore.Tests.Unit/Upserts.Spans.cs
+++ b/tests/ArrowDbCore.Tests.Unit/Upserts.Spans.cs
@@ -1,0 +1,56 @@
+﻿namespace ArrowDbCore.Tests.Unit;
+
+public class Upserts_Spans {
+    [Fact]
+    public async Task Upsert_Span_When_Not_Found_Inserts() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        ReadOnlySpan<char> key = "1";
+        db.Upsert(key, 1, JContext.Default.Int32);
+        Assert.True(db.ContainsKey(key));
+        Assert.Equal(1, db.Count);
+    }
+
+    [Fact]
+    public async Task Upsert_Span_When_Found_Overwrites() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        ReadOnlySpan<char> key = "1";
+        db.Upsert(key, 1, JContext.Default.Int32);
+        Assert.True(db.ContainsKey(key));
+        Assert.Equal(1, db.Count);
+        db.Upsert(key, 2, JContext.Default.Int32);
+        Assert.True(db.TryGetValue(key, JContext.Default.Int32, out var value));
+        Assert.Equal(2, value);
+    }
+
+    [Fact]
+    public async Task Conditional_Update_When_Not_Found_Inserts() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        ReadOnlySpan<char> key = "1";
+        Assert.True(db.Upsert(key, 1, JContext.Default.Int32, reference => reference == 3));
+    }
+
+    [Fact]
+    public async Task Conditional_Update_When_Found_And_Valid_Updates() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        ReadOnlySpan<char> key = "1";
+        db.Upsert(key, 1, JContext.Default.Int32);
+        Assert.True(db.Upsert(key, 3, JContext.Default.Int32, reference => reference == 1));
+        Assert.True(db.TryGetValue(key, JContext.Default.Int32, out var value));
+        Assert.Equal(3, value);
+    }
+
+    [Fact]
+    public async Task Conditional_Update_When_Found_And_Invalid_Returns_False() {
+        var db = await ArrowDb.CreateInMemory();
+        Assert.Equal(0, db.Count);
+        ReadOnlySpan<char> key = "1";
+        db.Upsert(key, 1, JContext.Default.Int32);
+        Assert.False(db.Upsert(key, 3, JContext.Default.Int32, reference => reference == 3));
+        Assert.True(db.TryGetValue(key, JContext.Default.Int32, out var value));
+        Assert.Equal(1, value);
+    }
+}


### PR DESCRIPTION
# Changelog

* Added overloads of `Upsert` that accept a `string` key, while the `ReadOnlySpan<char>` overloads are amazing in specific cases where its use can prevent a string allocation for the lookup, in other places where the input was originally a `string` that was implicitly converted to a `ReadOnlySpan<char>` for the parameter, this would've caused a copy to be allocated for the key when the key did not exist. The same scenario will now use the `string` overload and use it for the key directly, avoiding the intermediate copy.
* Added a `ValueTask` based `GetOrAddAsync` method, commonly used in caching scenarios.